### PR TITLE
Allow custom query to be used in dbfs

### DIFF
--- a/source/CustomQuery.cpp
+++ b/source/CustomQuery.cpp
@@ -1,0 +1,158 @@
+//****************************************************************************
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+//      Licensed under the MIT license.
+//
+// File: CustomQuery.cpp
+//
+// Purpose:
+//   This file contains definitions of functions used to enable custom
+//   query support.
+//
+#include "UtilsPrivate.h"
+
+// ---------------------------------------------------------------------------
+// Method: ExecuteCustomQuery
+//
+// Description:
+//  This method reads the query from queryFilePath and puts the output 
+//  in queryResultPath.
+//
+//  queryFilePath - absolute path to a file that contains query.
+//  queryResultPath - absolute path ot a file that is used to store query output.
+//
+// Returns:
+//    none.
+//
+void
+ExecuteCustomQuery(
+    const string& queryFilePath,
+    const string& queryResultPath,
+    const string& hostname,
+    const string& username,
+    const string& password)
+{
+    string responseString;
+
+    // Read the query
+    //
+    ifstream ifs(queryFilePath);
+    string query((std::istreambuf_iterator<char>(ifs)),
+                        (std::istreambuf_iterator<char>()));
+    PrintMsg("***** Query read = %s\n", query.c_str());
+    // Execute the query.
+    //
+    // We want the column names as well so use type as TYPE_TSV.
+    //
+    int result = ExecuteQuery(query, responseString, hostname,
+                              username, password, TYPE_TSV);
+
+    if (!result)
+    {
+        // Open file to write response.
+        //
+        int fd = open(queryResultPath.c_str(), O_RDWR);
+        if (fd == -1)
+        {
+            ReturnErrnoAndPrintError(__FUNCTION__, "open failed");
+        }
+        else
+        {
+            // Write in the response.
+            //
+            result = pwrite(fd, responseString.c_str(), responseString.length(), 0);
+            if (result == -1)
+            {
+                result = ReturnErrnoAndPrintError(__FUNCTION__, "pwrite failed");
+            }
+
+            // Close fd after write.
+            //
+            result = close(fd);
+            if (result == -1)
+            {
+                result = ReturnErrnoAndPrintError(__FUNCTION__, "close failed");
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Method: RemoveCustomQueriesOutputFiles
+//
+// Description:
+//  Remove all the files under custom query dump directory.
+//
+//  dumpPath - absolute path to a custom query dump directory.
+//
+// Returns:
+//    none.
+//
+void RemoveCustomQueriesOutputFiles(
+    DIR* dp,
+    const string& dumpPath)
+{
+    struct dirent*  de;
+    string          filepath;
+
+    // Remove old files from custom query dump directory
+    //
+    while ((de = readdir(dp)) != NULL)
+    {
+        if (de->d_type == DT_REG)
+        {
+            filepath = StringFormat("%s/%s", dumpPath.c_str(), de->d_name);
+
+            // Do the best to remove the file
+            //
+            (void) remove(filepath.c_str());
+
+            fprintf(stderr, "Remove %s\n", filepath.c_str());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Method: CreateCustomQueriesOutputFiles
+//
+// Description:
+//  Create 
+//
+//  dumpPath - absolute path to a custom query dump directory.
+//
+// Returns:
+//    none.
+//
+void CreateCustomQueriesOutputFiles(
+    const string& servername,
+    const string& dumpPath)
+{
+    DIR*            userQueriesDir;
+    string          userQueriesPath;
+    string          filepath;
+    struct dirent*  de;
+
+    userQueriesPath = GetUserCustomQueryPath(servername);
+    if (!userQueriesPath.empty())
+    {
+        // Open user customQueries dir 
+        //
+        userQueriesDir = opendir(userQueriesPath.c_str());
+        if (userQueriesDir)
+        {
+            // Read all files in customQueries dir
+            //
+            while((de = readdir(userQueriesDir)) != NULL)
+            {
+                if (de->d_type == DT_REG)
+                {
+                    // Create new files with the same name in
+                    // the dump directory for storing results
+                    //
+                    filepath = StringFormat("%s/%s", dumpPath.c_str(), de->d_name);
+                    CreateFile(filepath.c_str());
+                }
+            }
+            closedir(userQueriesDir);
+        }
+    }
+}

--- a/source/CustomQuery.cpp
+++ b/source/CustomQuery.cpp
@@ -38,7 +38,6 @@ ExecuteCustomQuery(
     ifstream ifs(queryFilePath);
     string query((std::istreambuf_iterator<char>(ifs)),
                         (std::istreambuf_iterator<char>()));
-    PrintMsg("***** Query read = %s\n", query.c_str());
     // Execute the query.
     //
     // We want the column names as well so use type as TYPE_TSV.
@@ -87,7 +86,8 @@ ExecuteCustomQuery(
 // Returns:
 //    none.
 //
-void RemoveCustomQueriesOutputFiles(
+void 
+RemoveCustomQueriesOutputFiles(
     DIR* dp,
     const string& dumpPath)
 {
@@ -105,8 +105,6 @@ void RemoveCustomQueriesOutputFiles(
             // Do the best to remove the file
             //
             (void) remove(filepath.c_str());
-
-            fprintf(stderr, "Remove %s\n", filepath.c_str());
         }
     }
 }
@@ -122,7 +120,8 @@ void RemoveCustomQueriesOutputFiles(
 // Returns:
 //    none.
 //
-void CreateCustomQueriesOutputFiles(
+void 
+CreateCustomQueriesOutputFiles(
     const string& servername,
     const string& dumpPath)
 {

--- a/source/CustomQuery.h
+++ b/source/CustomQuery.h
@@ -1,0 +1,30 @@
+//****************************************************************************
+//      Copyright (c) Microsoft Corporation. All rights reserved.
+//      Licensed under the MIT license.
+//
+// File: CustomQuery.h
+//
+// Purpose:
+//   This file contains declarations of functions used to enable custom
+//   query support.
+//
+#pragma once
+
+// Name of folder in which user needs to create custom query.
+//
+#define CUSTOM_QUERY_FOLDER_NAME                    "customQueries"
+
+// Once query is processed -rename original file to end with
+// this phrase.
+//
+#define CUSTOM_QUERY_OUTPUT_FILE_NAME_TERMINATION   "_output"
+
+// Time the thread should sleep before checking in the folders again.
+//
+#define CUSTOM_QUERY_THREAD_SLEEP_TIME_SECONDS      2
+
+
+// This method is the function that the custom query thread starts
+// with and helps implement the custom query support.
+//
+void CheckForCustomQueries();

--- a/source/CustomQuery.h
+++ b/source/CustomQuery.h
@@ -14,17 +14,24 @@
 //
 #define CUSTOM_QUERY_FOLDER_NAME                    "customQueries"
 
-// Once query is processed -rename original file to end with
-// this phrase.
+// Execute a user custom query
 //
-#define CUSTOM_QUERY_OUTPUT_FILE_NAME_TERMINATION   "_output"
+void
+ExecuteCustomQuery(
+    const string& queryFilePath,
+    const string& queryResultPath,
+    const string& hostname,
+    const string& username,
+    const string& password);
 
-// Time the thread should sleep before checking in the folders again.
+// Remove all the output files in custom query dump directory.
 //
-#define CUSTOM_QUERY_THREAD_SLEEP_TIME_SECONDS      2
+void RemoveCustomQueriesOutputFiles(
+    DIR* dp,
+    const string& dumpPath);
 
-
-// This method is the function that the custom query thread starts
-// with and helps implement the custom query support.
+// Create output files in custom query dump directory.
 //
-void CheckForCustomQueries();
+void CreateCustomQueriesOutputFiles(
+    const string& servername,
+    const string& dumpPath);

--- a/source/Makefile
+++ b/source/Makefile
@@ -18,3 +18,6 @@ $(TARGET): $(OBJECTS)
 clean:
 	$(AT)rm -rf *.o
 	$(AT)rm -rf $(TARGET)
+
+debug: CFLAGS += -g
+debug: all

--- a/source/SQLQuery.cpp
+++ b/source/SQLQuery.cpp
@@ -18,7 +18,7 @@
 //    error has occurred.
 //
 // Returns:
-//    none.
+//    int
 //
 int DBErrorHandler(
     DBPROCESS* dbproc,

--- a/source/SQLQuery.cpp
+++ b/source/SQLQuery.cpp
@@ -8,9 +8,7 @@
 //   This file contains the backend function definitions used to query
 //   the SQL server.
 //
-
 #include "UtilsPrivate.h"
-
 
 // ---------------------------------------------------------------------------
 // Method: DBErrorHandler
@@ -89,10 +87,10 @@ void UninstallDBHandlers()
 //
 static RETCODE
 CreateConnectionAndRunQuery(
-    string query,
-    string dbServer,
-    string username,
-    string password,
+    const string& query,
+    const string& dbServer,
+    const string& username,
+    const string& password,
     DBPROCESS*& dbConn)
 {
     LOGINREC*   login;
@@ -356,12 +354,12 @@ static void
 //
 int
 ExecuteQuery(
-    string query,
+    const string& query,
     string& output,
-    string dbServer,
-    string username,
-    string password,
-    enum FileFormat type)
+    const string& dbServer,
+    const string& username,
+    const string& password,
+    const FileFormat type)
 {
     DBPROCESS*      dbConn;
     RETCODE         status = FAIL;

--- a/source/SQLQuery.h
+++ b/source/SQLQuery.h
@@ -8,11 +8,7 @@
 //   This file contains the backend function declarations used to query
 //   the SQL server.
 //
-
 #pragma once
-
-#ifndef _SQL__QUERY_H_
-#define _SQL__QUERY_H_
 
 #define progName                        "sqlserverFS"
 #define dbName                          "master"
@@ -48,4 +44,3 @@ VerifyServerInfo(
     string username,
     string password);
 
-#endif

--- a/source/SQLQuery.h
+++ b/source/SQLQuery.h
@@ -32,12 +32,12 @@ enum FileFormat
 // This method executes the provided SQL query on the given server.
 //
 int ExecuteQuery(
-    string query,
+    const string& query,
     string& output,
-    string dbServer,
-    string username,
-    string password,
-    enum FileFormat type);
+    const string& dbServer,
+    const string& username,
+    const string& password,
+    const FileFormat type);
 
 // This method checks if DB-Lib is able to connect with the given 
 // credentials of the given IP address.

--- a/source/UtilsPrivate.h
+++ b/source/UtilsPrivate.h
@@ -138,6 +138,7 @@ using std::cin;
 #include <sybdb.h>
 #include <syberror.h>
 #include <termios.h>
+#include <cstddef>
 
 // ---------------------------------------------------------------------------
 // Local headers of utility files
@@ -148,5 +149,14 @@ using std::cin;
 #include "helper.h"
 #include "INIFile.h"
 #include "ParseException.h"
+
+// Common symbols needed by all files.
+//
+extern struct SQLFsPaths g_UserPaths;
+extern bool g_InVerbose;
+extern unordered_map<string, class ServerInfo*> g_ServerInfoMap;
+extern bool g_UseLogFile;
+extern bool g_RunInForeground;
+extern char g_LocallyGeneratedFiles[];
 
 #endif

--- a/source/UtilsPrivate.h
+++ b/source/UtilsPrivate.h
@@ -11,9 +11,6 @@
 //
 #pragma once
 
-#ifndef _UTILS_PRIVATE_
-#define _UTILS_PRIVATE_ 
-
 // ---------------------------------------------------------------------------
 // C++ STL Headers
 //
@@ -149,6 +146,7 @@ using std::cin;
 #include "helper.h"
 #include "INIFile.h"
 #include "ParseException.h"
+#include "CustomQuery.h"
 
 // Common symbols needed by all files.
 //
@@ -158,5 +156,3 @@ extern unordered_map<string, class ServerInfo*> g_ServerInfoMap;
 extern bool g_UseLogFile;
 extern bool g_RunInForeground;
 extern char g_LocallyGeneratedFiles[];
-
-#endif

--- a/source/helper.cpp
+++ b/source/helper.cpp
@@ -295,6 +295,16 @@ CreateDMVFiles(
             strerror(errno));
     }
 
+    // Create the custom query folder for each server.
+    //
+    string customQueryFolderPath = fpath + LINUX_PATH_DELIM + CUSTOM_QUERY_FOLDER_NAME;
+    result = mkdir(customQueryFolderPath.c_str(), DEFAULT_PERMISSIONS);
+    if (result)
+    {
+        PrintMsg("mkdir failed for %s- %s\n", customQueryFolderPath.c_str(),
+                 strerror(errno));
+    }
+
     if (!result)
     {
         // Query SQL server for all the DMV files to be created.

--- a/source/helper.cpp
+++ b/source/helper.cpp
@@ -146,10 +146,10 @@ PrintMsg(const char* format, ...)
 //
 void
 GetServerDetails(
-string servername,
-string& hostname,
-string& username,
-string& password)
+    string servername,
+    string& hostname,
+    string& username,
+    string& password)
 {
     auto search = g_ServerInfoMap.find(servername);
 
@@ -215,17 +215,17 @@ CreateFile(
 }
 
 // ---------------------------------------------------------------------------
-// Method: IsDmvFile
+// Method: IsDbfsFile
 //
 // Description:
 //  This checks if the file pointed to by the provided path is a
-//  DMV file (created by the tool).
+//  dbfs file (created by this tool).
 //
 // Returns:
 //    true if file is a dmv - otherwise false.
 //
 bool
-IsDmvFile(
+IsDbfsFile(
     const char* path)
 {
     string fpath;
@@ -388,3 +388,52 @@ KillSelf()
     kill(getpid(), SIGHUP);
 }
 
+// ---------------------------------------------------------------------------
+// Method: GetServerInfo
+//
+// Description:
+//    Given a server name, look up ServerInfo from ServerInfoMap.
+//    The map was created by parsing the config file.
+//
+// Returns:
+//    Pointer to ServerInfo object or NULL if the server does not exist
+//
+ServerInfo* GetServerInfo(
+    const string& servername)
+{
+    ServerInfo* serverInfo = NULL;
+
+    // Lookup the server name in the map
+    //
+    auto server = g_ServerInfoMap.find(servername);
+    if (server != g_ServerInfoMap.end())
+    {
+        serverInfo = server->second;
+    }
+
+    return serverInfo;
+}
+
+// ---------------------------------------------------------------------------
+// Method: GetUserCustomQueryPath
+//
+// Description:
+//    Given a server name, get a customer query path that was specified by
+//    the user in config file.
+//
+// Returns:
+//    - Empty string if the server does not exist.
+//    - Canonical path to custom query directory that user specify in config
+//      file for that specific servername.
+//
+string GetUserCustomQueryPath(
+    const string& servername)
+{
+    string customQueryPath;
+    ServerInfo* serverInfo = GetServerInfo(servername);
+    if (serverInfo)
+    {
+        customQueryPath = serverInfo->m_customQueriesPath;
+    }
+    return customQueryPath;
+}

--- a/source/helper.h
+++ b/source/helper.h
@@ -8,16 +8,12 @@
 //   This file contains the declarations of helper functions used by
 //   sqlfs and SQLQuery.
 //
-
 #pragma once
 
-#ifndef _SQL_HELPER_H_
-#define _SQL_HELPER_H_
-
-#define SUCCESS 0
-#define FAILURE 1
-
-#define DEFAULT_PERMISSIONS 0777
+#define SUCCESS                 0
+#define FAILURE                 1
+#define DEFAULT_PERMISSIONS     0777
+#define LINUX_PATH_DELIM        "/"
 
 // This method concatenates the dump directory path to the provided 
 // relative path.
@@ -81,5 +77,3 @@ CreateDMVFiles(
 //
 void
 KillSelf();
-
-#endif

--- a/source/helper.h
+++ b/source/helper.h
@@ -58,6 +58,13 @@ void
 CreateFile(
     const char* path);
 
+// This checks if the file pointed to by the provided path is a
+// DMV file (created by the tool).
+//
+bool
+IsDmvFile(
+    const char* path);
+
 // This method creates the empty DMV files for a given server.
 // The virtual location of the files (as seen) is <MOUNT DIR>/<SERVER NAME>/.
 //

--- a/source/helper.h
+++ b/source/helper.h
@@ -55,10 +55,10 @@ CreateFile(
     const char* path);
 
 // This checks if the file pointed to by the provided path is a
-// DMV file (created by the tool).
+// dbfs file (created by this tool).
 //
 bool
-IsDmvFile(
+IsDbfsFile(
     const char* path);
 
 // This method creates the empty DMV files for a given server.
@@ -77,3 +77,13 @@ CreateDMVFiles(
 //
 void
 KillSelf();
+
+// Given a server name, get ServerInfo.
+//
+ServerInfo* GetServerInfo(
+    const string& servername);
+
+// Given a server name, get the user specified custom query directory.
+//
+string GetUserCustomQueryPath(
+    const string& servername);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -155,7 +155,7 @@ ParseArguments(
     {
         // Default values
         //
-        g_UserPaths.m_dumpPath = "/tmp/" + dumpDirPath + "/";
+        g_UserPaths.m_dumpPath = "/tmp/" + dumpDirPath + LINUX_PATH_DELIM;
 
         mountSet = false;
         confSet = false;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -543,7 +543,7 @@ ParseConfigFile(void)
     string          username;
     string          password;    
     string          version;
-    string          customQueryPath;
+    string          customQueriesPath;
     int             versionInt;
     int             itrNum = 0;
     map<std::string, SectionNameValuePair>::iterator sectionItr;
@@ -590,13 +590,13 @@ ParseConfigFile(void)
             }
             if (status)
             {
-                status = ParseSectionEntry(sectionItr, "customQueryPath", customQueryPath);
+                status = ParseSectionEntry(sectionItr, "customQueriesPath", customQueriesPath);
                 if (status)
                 {
-                    char* tempPtr = realpath(customQueryPath.c_str(), NULL);
+                    char* tempPtr = realpath(customQueriesPath.c_str(), NULL);
                     if (tempPtr)
                     {
-                        customQueryPath = tempPtr;
+                        customQueriesPath = tempPtr;
                         free(tempPtr);
                     }
                     else
@@ -643,7 +643,7 @@ ParseConfigFile(void)
                 serverInfoEntry->m_username = username;
                 serverInfoEntry->m_password = password;
                 serverInfoEntry->m_version = versionInt;
-                serverInfoEntry->m_customQueriesPath = customQueryPath;
+                serverInfoEntry->m_customQueriesPath = customQueriesPath;
             }
             else
             {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -541,8 +541,9 @@ ParseConfigFile(void)
     string          serverName;
     string          hostname;
     string          username;
-    string          password;
+    string          password;    
     string          version;
+    string          customQueryPath;
     int             versionInt;
     int             itrNum = 0;
     map<std::string, SectionNameValuePair>::iterator sectionItr;
@@ -589,6 +590,23 @@ ParseConfigFile(void)
             }
             if (status)
             {
+                status = ParseSectionEntry(sectionItr, "customQueryPath", customQueryPath);
+                if (status)
+                {
+                    char* tempPtr = realpath(customQueryPath.c_str(), NULL);
+                    if (tempPtr)
+                    {
+                        customQueryPath = tempPtr;
+                        free(tempPtr);
+                    }
+                    else
+                    {
+                        status = false;
+                    }
+                }
+            }
+            if (status)
+            {
                 status = ParseSectionEntry(sectionItr, "password", password);
 
                 // Query user for password in case nothing in config file
@@ -625,6 +643,7 @@ ParseConfigFile(void)
                 serverInfoEntry->m_username = username;
                 serverInfoEntry->m_password = password;
                 serverInfoEntry->m_version = versionInt;
+                serverInfoEntry->m_customQueriesPath = customQueryPath;
             }
             else
             {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -32,6 +32,16 @@ bool g_UseLogFile;
 //
 bool g_RunInForeground;
 
+// Value of extended attribute that specifies is this is a DMV file
+// created by the tool.
+//
+// This will help decide if this is a DMV whose content
+// needs to be queried from the server.
+//
+// This will just be an empty attribute set.
+//
+char g_LocallyGeneratedFiles[] = "user.isCreatedByTool";
+
 // ---------------------------------------------------------------------------
 // Method: PrintUsageAndExit
 //
@@ -138,11 +148,13 @@ ParseArguments(
 
     status = false;
 
-    // Generate name of dump dir
+    // Generate name of dump directory.
+    //
     status = GenerateFileName(dumpDirPath);
     if (status)
     {
         // Default values
+        //
         g_UserPaths.m_dumpPath = "/tmp/" + dumpDirPath + "/";
 
         mountSet = false;
@@ -150,6 +162,7 @@ ParseArguments(
     }
 
     // Parsing
+    //
     while (status)
     {
         idx = 0;
@@ -157,7 +170,8 @@ ParseArguments(
 
         if (option == -1)
         {
-            // End of argument options
+            // End of argument options.
+            //
             break;
         }
 
@@ -223,6 +237,7 @@ ParseArguments(
     if (status)
     {
         // Mount path must be provided by the user.
+        //
         if (!mountSet)
         {
             fprintf(stderr, "###### Enter mount directory\n");
@@ -230,6 +245,7 @@ ParseArguments(
         }
 
         // Config file path must be provided by the user.
+        //
         if (!confSet)
         {
             fprintf(stderr, "###### Enter conf file path\n");
@@ -702,7 +718,8 @@ main(
     FILE* filePtr;
     bool status;
 
-    // Rejecting request if root is trying to run this
+    // Rejecting request if root is trying to run this.
+    //
     if ((getuid() == 0) || (geteuid() == 0))
     {
         fprintf(stderr, "DBFS should not be started with root privileges. "
@@ -716,10 +733,12 @@ main(
     {
         ParseArguments(argc, argv);
 
-        // Check if the set paths are valid
+        // Check if the set paths are valid.
+        //
         CheckAllSetPaths();
 
-        // Open the log-file path if given and in verbose mode
+        // Open the log-file path if given and in verbose mode.
+        //
         if (g_InVerbose && g_UseLogFile)
         {
             filePtr = fopen(g_UserPaths.m_logfilePath.c_str(), "w");

--- a/source/sqlfs.cpp
+++ b/source/sqlfs.cpp
@@ -27,11 +27,12 @@ GetattrLocalImpl(
     const char* path,
     struct stat* stbuf)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = lstat(fpath.c_str(), stbuf);
     if (result == -1)
     {
@@ -41,6 +42,7 @@ GetattrLocalImpl(
         result = -errno;
     }
 
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -58,17 +60,18 @@ AccessLocalImpl(
     const char* path,
     int mask)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = access(fpath.c_str(), mask);
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "access failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -87,11 +90,12 @@ ReadlinkLocalImpl(
     char* buf,
     size_t size)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = readlink(fpath.c_str(), buf, size - 1);
     if (result == -1)
     {
@@ -101,7 +105,7 @@ ReadlinkLocalImpl(
     {
         buf[result] = '\0';
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -122,6 +126,7 @@ ReaddirLocalImpl(
     off_t offset,
     struct fuse_file_info* fi)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     DIR*            dp;
     struct dirent*  de;
     string          fpath;
@@ -131,7 +136,7 @@ ReaddirLocalImpl(
     (void)offset;
     (void)fi;
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     dp = opendir(fpath.c_str());
     if (dp == NULL)
     {
@@ -151,7 +156,7 @@ ReaddirLocalImpl(
 
         closedir(dp);
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -170,11 +175,12 @@ MknodLocalImpl(
     mode_t mode,
     dev_t rdev)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     if (S_ISREG(mode))
     {
         result = open(fpath.c_str(), O_CREAT | O_EXCL | O_WRONLY, mode);
@@ -207,7 +213,7 @@ MknodLocalImpl(
             result = ReturnErrnoAndPrintError(__FUNCTION__, "mknod failed");
         }
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -225,17 +231,18 @@ MkdirLocalImpl(
     const char* path,
     mode_t mode)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = mkdir(fpath.c_str(), mode);
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "mkdir failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -252,17 +259,18 @@ static int
 UnlinkLocalImpl(
     const char* path)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = unlink(fpath.c_str());
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "unlink failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -279,17 +287,18 @@ static int
 RmdirLocalImpl(
     const char* path)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = rmdir(fpath.c_str());
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "rmdir failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -307,19 +316,21 @@ SymlinkLocalImpl(
     const char* from,
     const char* to)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
     string  tpath;
 
     fpath = CalculateDumpPath(from);
     tpath = CalculateDumpPath(to);
-
+    fprintf(stderr, "\tFROM Original path = %s\n\tFROM Converted path =%s\n", from, fpath.c_str());
+    fprintf(stderr, "\tTO Original path = %s\n\tTO converted path =%s\n", to, tpath.c_str());
     result = symlink(fpath.c_str(), tpath.c_str());
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "symlink failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -337,19 +348,21 @@ RenameLocalImpl(
     const char* from,
     const char* to)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
     string  tpath;
 
     fpath = CalculateDumpPath(from);
     tpath = CalculateDumpPath(to);
-
+    fprintf(stderr, "\tFROM Original path = %s\n\tFROM Converted path =%s\n", from, fpath.c_str());
+    fprintf(stderr, "\tTO Original path = %s\n\tTO converted path =%s\n", to, tpath.c_str());
     result = rename(fpath.c_str(), tpath.c_str());
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "rename failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -367,19 +380,21 @@ LinkLocalImpl(
     const char* from,
     const char* to)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
     string  tpath;
 
     fpath = CalculateDumpPath(from);
     tpath = CalculateDumpPath(to);
-
+    fprintf(stderr, "\tFROM Original path = %s\n\tFROM Converted path =%s\n", from, fpath.c_str());
+    fprintf(stderr, "\tTO Original path = %s\n\tTO converted path =%s\n", to, tpath.c_str());
     result = link(fpath.c_str(), tpath.c_str());
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "link failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -397,17 +412,18 @@ ChmodLocalImpl(
     const char* path,
     mode_t mode)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = chmod(fpath.c_str(), mode);
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "chmod failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -426,17 +442,18 @@ ChownLocalImpl(
     uid_t username,
     gid_t gid)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = lchown(fpath.c_str(), username, gid);
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "lchown failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -454,17 +471,18 @@ TruncateLocalImpl(
     const char* path,
     off_t size)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = truncate(fpath.c_str(), size);
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "truncate failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -482,11 +500,12 @@ UtimensLocalImpl(
     const char* path,
     const struct timespec ts[2])
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     // Not using utime/utimes since they follow symlinks.
     //
     result = utimensat(0, fpath.c_str(), ts, AT_SYMLINK_NOFOLLOW);
@@ -494,7 +513,7 @@ UtimensLocalImpl(
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "utimensat failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -510,7 +529,7 @@ UtimensLocalImpl(
 //
 static void
 GetFileDescriptorForPath(
-    string path,
+    const char* path,
     struct fuse_file_info* fi,
     int& fd)
 {
@@ -521,18 +540,20 @@ GetFileDescriptorForPath(
     if (!fi)
     {
         fpath = CalculateDumpPath(path);
-
+        fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
         // Open the file.
         //
-        fd = open(fpath.c_str(), O_RDONLY);
+        fd = open(fpath.c_str(), fi->flags);
         if (fd == -1)
         {
             ReturnErrnoAndPrintError(__FUNCTION__, "open failed");
         }
+        fprintf(stderr, "\t** Opened new FD = %d\n", fd);
     }
     else
     {
         fd = fi->fh;
+        fprintf(stderr, "\t** Using old fd = %d\n", fd);
     }
 }
 
@@ -549,12 +570,12 @@ GetFileDescriptorForPath(
 //
 static void
 CloseFileDesciptorIfOpened(
-    string path,
     struct fuse_file_info* fi,
     int fd)
 {
     if (!fi)
     {
+        fprintf(stderr, "\t** Closing FD = %d in %s\n", fd, __FUNCTION__);
         int result = close(fd);
         if (result)
         {
@@ -703,10 +724,10 @@ OpenLocalImpl(
     string fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     // Open the file.
     //
-    fd = open(fpath.c_str(), O_RDONLY);
+    fd = open(fpath.c_str(), fi->flags);
     if (fd == -1)
     {
         error = ReturnErrnoAndPrintError(__FUNCTION__, "open failed");
@@ -716,7 +737,6 @@ OpenLocalImpl(
         // Save fd for later use.
         //
         fi->fh = fd;
-        fprintf(stderr, "\t** Open successful with FD = %d flags %d\n", fd, fi->flags);
     }
 
     if (!error)
@@ -798,6 +818,7 @@ ReadLocalImpl(
     off_t offset,
     struct fuse_file_info* fi)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int fd = 0;
     int result = -1;
 
@@ -807,15 +828,16 @@ ReadLocalImpl(
 
     if (fd != -1)
     {
+        fprintf(stderr, "\t** Trying to read with FD = %d\n", fd);
         result = pread(fd, buf, size, offset);
         if (result == -1)
         {
             result = ReturnErrnoAndPrintError(__FUNCTION__, "pread failed");
         }
 
-        CloseFileDesciptorIfOpened(path, fi, fd);
+        CloseFileDesciptorIfOpened(fi, fd);
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -836,6 +858,7 @@ WriteLocalImpl(
     off_t offset,
     struct fuse_file_info* fi)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     fd;
     string  fpath;
     int     result = 0;
@@ -846,13 +869,14 @@ WriteLocalImpl(
 
         if (fd != -1)
         {
+            fprintf(stderr, "\t** Trying to write with FD = %d\n", fd);
             result = pwrite(fd, buf, size, offset);
             if (result == -1)
             {
                 result = ReturnErrnoAndPrintError(__FUNCTION__, "pwrite failed");
             }
 
-            CloseFileDesciptorIfOpened(path, fi, fd);
+            CloseFileDesciptorIfOpened(fi, fd);
         }
     }
     else
@@ -862,7 +886,7 @@ WriteLocalImpl(
         PrintMsg("Cannot write to the DMV files.\n");
         result = -EPERM;
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -881,17 +905,18 @@ StatfsLocalImpl(
     const char* path,
     struct statvfs* stbuf)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = statvfs(fpath.c_str(), stbuf);
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__, "statvfs failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -913,6 +938,7 @@ ReleaseLocalImpl(
     const char* path,
     struct fuse_file_info* fi)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int result = 0;
 
     if (IsDmvFile(path))
@@ -927,13 +953,14 @@ ReleaseLocalImpl(
         }
     }
 
+    fprintf(stderr, "\t** Trying to CLOSE FD = %lu\n", fi->fh);
     result = close(fi->fh);
     if (result == -1)
     {
         result = ReturnErrnoAndPrintError(__FUNCTION__,
                                           "close failed");
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -956,7 +983,7 @@ FsyncLocalImpl(
     (void)path;
     (void)isdatasync;
     (void)fi;
-
+    fprintf(stderr, "%s NOT IMPLEMENTED ****\n", __FUNCTION__);
     return 0;
 }
 
@@ -977,6 +1004,7 @@ FallocateLocalImpl(
     off_t length,
     struct fuse_file_info* fi)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     fd;
     string  fpath;
     int     result = 0;
@@ -994,9 +1022,9 @@ FallocateLocalImpl(
             result = -posix_fallocate(fd, offset, length);
         }
 
-        CloseFileDesciptorIfOpened(path, fi, fd);
+        CloseFileDesciptorIfOpened(fi, fd);
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -1017,17 +1045,18 @@ SetxattrLocalImpl(
     size_t size, 
     int flags)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = lsetxattr(fpath.c_str(), name, value, size, flags);
     if (result == -1)
     {
         result = -errno;
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -1047,17 +1076,18 @@ GetxattrLocalImpl(
     char* value,
     size_t size)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = lgetxattr(fpath.c_str(), name, value, size);
     if (result == -1)
     {
         result = -errno;
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -1076,17 +1106,18 @@ ListxattrLocalImpl(
     char* list,
     size_t size)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = llistxattr(fpath.c_str(), list, size);
     if (result == -1)
     {
         result = -errno;
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -1104,17 +1135,18 @@ RemovexattrLocalImpl(
     const char* path,
     const char* name)
 {
+    fprintf(stderr, "%s START\n", __FUNCTION__);
     int     result;
     string  fpath;
 
     fpath = CalculateDumpPath(path);
-
+    fprintf(stderr, "\tOriginal path = %s\n\tConverted path =%s\n", path, fpath.c_str());
     result = lremovexattr(fpath.c_str(), name);
     if (result == -1)
     {
         result = -errno;
     }
-
+    fprintf(stderr, "%s FINISH with result %d\n", __FUNCTION__, result);
     return result;
 }
 
@@ -1176,8 +1208,6 @@ InitializeSQLFs(
 void
 DestroySQLFs(void* userdata)
 {
-    string  command;
-
     PrintMsg("Closing SQLFS\n");
 }
 
@@ -1300,6 +1330,9 @@ StartFuse(
     buffer = strdup("direct_io");
     assert(buffer);
     argv[argc++] = buffer;
+
+    std::thread t(CheckForCustomQueries);
+    t.detach();
 
     PrintMsg("Starting fuse\n");
 

--- a/source/sqlfs.cpp
+++ b/source/sqlfs.cpp
@@ -1244,9 +1244,9 @@ InitializeFuseOperations(
     sqlFsOperations->getxattr = GetxattrLocalImpl;
     sqlFsOperations->listxattr = ListxattrLocalImpl;
     sqlFsOperations->removexattr = RemovexattrLocalImpl;
-    sqlFsOperations->opendir = NULL;
+    sqlFsOperations->opendir = OpendirLocalImpl;
     sqlFsOperations->readdir = ReaddirLocalImpl;
-    sqlFsOperations->releasedir = NULL;
+    sqlFsOperations->releasedir = ReleasedirLocalImpl;
     sqlFsOperations->fsyncdir = NULL;
     sqlFsOperations->init = InitializeSQLFs;
     sqlFsOperations->destroy = DestroySQLFs;
@@ -1331,8 +1331,8 @@ StartFuse(
     assert(buffer);
     argv[argc++] = buffer;
 
-    std::thread t(CheckForCustomQueries);
-    t.detach();
+    //std::thread t(CheckForCustomQueries);
+    //t.detach();
 
     PrintMsg("Starting fuse\n");
 

--- a/source/sqlfs.h
+++ b/source/sqlfs.h
@@ -8,11 +8,7 @@
 //   This file contains the declarations of various structures
 //   used by the SQL FS to get server information and paths.
 //
-
 #pragma once
-
-#ifndef _SQL_FS_H_
-#define _SQL_FS_H_
 
 #define MAX_ARGS                8
 
@@ -39,5 +35,3 @@ public:
 };
 
 int StartFuse(char* ProgramName);
-
-#endif

--- a/source/sqlfs.h
+++ b/source/sqlfs.h
@@ -26,12 +26,20 @@ struct SQLFsPaths
 //
 class ServerInfo 
 {
-
 public:
     string m_hostname;
     string m_username;
     string m_password;
+
+    // This is a canonicalized path to user custom queries directory
+    // that was specified in the config file.
+    //
     string m_customQueriesPath;
+
+    // Sql server version. The version number is used to determine
+    // if JSON output is supported. Value for SQL Server 2016 is [16].
+    // [16] is the minimum version required for JSON output.
+    //
     int m_version;
 };
 

--- a/source/sqlfs.h
+++ b/source/sqlfs.h
@@ -31,6 +31,7 @@ public:
     string m_hostname;
     string m_username;
     string m_password;
+    string m_customQueriesPath;
     int m_version;
 };
 


### PR DESCRIPTION
This change is to address issue #5. This change allows user to specify a directory which contains custom query files. Most of the proposed behavior in #5 is supported with this change. Except that we do not report query error. This new configuration is required in config file.

`customqueriespath=<path to directory>`

I have not tested what happen to the output if the query returns multiple result sets yet. 

Todo:
- Currently the output file does not report query error. 
- customqueries config is not an optional config. If the config file does not have this config, dbfs will not starts after this change.
- Control query access to be read-only. Otherwise user can do harm to the database.