### PR TITLE
Minor fix

### DIFF
--- a/source/helper.h
+++ b/source/helper.h
@@ -61,16 +61,16 @@ bool
 IsDbfsFile(
     const char* path);
 
-// This method creates the empty DMV files for a given server.
+// This method creates the empty DMV files and custom query files for a given server.
 // The virtual location of the files (as seen) is <MOUNT DIR>/<SERVER NAME>/.
 //
 void
-CreateDMVFiles(
-    string servername,
-    string hostname,
-    string username,
-    string password,
-    int version);
+CreateDbfsFiles(
+    const string& servername,
+    const string& hostname,
+    const string& username,
+    const string& password,
+    const int version);
 
 // This method exits the program and in doing so the function DestroySQLFs
 // is called.

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -385,7 +385,7 @@ ParseSectionEntry(
     map<std::string, SectionNameValuePair>::iterator sectionItr,
     const string& entryName,
     string& entryValue,
-    bool optional)
+    bool optional = false)
 {
     bool status;
     auto&& entryItr = sectionItr->second.begin();
@@ -578,15 +578,15 @@ ParseConfigFile(void)
             //
             if (status)
             {
-                status = ParseSectionEntry(sectionItr, "hostname", hostname, false);
+                status = ParseSectionEntry(sectionItr, "hostname", hostname);
             }
             if (status)
             {
-                status = ParseSectionEntry(sectionItr, "username", username, false);
+                status = ParseSectionEntry(sectionItr, "username", username);
             }
             if (status)
             {
-                status = ParseSectionEntry(sectionItr, "version", version, false);
+                status = ParseSectionEntry(sectionItr, "version", version);
                 if (status)
                 {
                     status = convertToInt(version, versionInt);
@@ -611,7 +611,7 @@ ParseConfigFile(void)
             }
             if (status)
             {
-                status = ParseSectionEntry(sectionItr, "password", password, false);
+                status = ParseSectionEntry(sectionItr, "password", password);
 
                 // Query user for password in case nothing in config file
                 //

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -383,8 +383,9 @@ CheckAllSetPaths(void)
 static bool
 ParseSectionEntry(
     map<std::string, SectionNameValuePair>::iterator sectionItr,
-    string entryName,
-    string& entryValue)
+    const string& entryName,
+    string& entryValue,
+    bool optional)
 {
     bool status;
     auto&& entryItr = sectionItr->second.begin();
@@ -404,15 +405,18 @@ ParseSectionEntry(
     }
     else
     {
-        fprintf(stderr, "No \"%s\" entry for section %s.\n",
-            entryName.c_str(),
-            sectionItr->first.c_str());
+        if (!optional)
+        {
+            fprintf(stderr, "No \"%s\" entry for section %s.\n",
+                entryName.c_str(),
+                sectionItr->first.c_str());
+
+            status = false;
+        }
 
         // Clear the output string since no such section was found
         //
         entryValue.clear();
-
-        status = false;
     }
 
     return status;
@@ -574,15 +578,15 @@ ParseConfigFile(void)
             //
             if (status)
             {
-                status = ParseSectionEntry(sectionItr, "hostname", hostname);
+                status = ParseSectionEntry(sectionItr, "hostname", hostname, false);
             }
             if (status)
             {
-                status = ParseSectionEntry(sectionItr, "username", username);
+                status = ParseSectionEntry(sectionItr, "username", username, false);
             }
             if (status)
             {
-                status = ParseSectionEntry(sectionItr, "version", version);
+                status = ParseSectionEntry(sectionItr, "version", version, false);
                 if (status)
                 {
                     status = convertToInt(version, versionInt);
@@ -590,8 +594,8 @@ ParseConfigFile(void)
             }
             if (status)
             {
-                status = ParseSectionEntry(sectionItr, "customQueriesPath", customQueriesPath);
-                if (status)
+                status = ParseSectionEntry(sectionItr, "customQueriesPath", customQueriesPath, true);
+                if (status && !customQueriesPath.empty())
                 {
                     char* tempPtr = realpath(customQueriesPath.c_str(), NULL);
                     if (tempPtr)
@@ -607,7 +611,7 @@ ParseConfigFile(void)
             }
             if (status)
             {
-                status = ParseSectionEntry(sectionItr, "password", password);
+                status = ParseSectionEntry(sectionItr, "password", password, false);
 
                 // Query user for password in case nothing in config file
                 //

--- a/source/sqlfs.cpp
+++ b/source/sqlfs.cpp
@@ -815,19 +815,22 @@ OpenLocalImpl(
                 {
                     userQueriesPath = serverInfo->m_customQueriesPath;
 
-                    // Construct the full path name to the query file
-                    //
-                    queryFilePath = StringFormat("%s/%s", userQueriesPath.c_str(), filename.c_str());
-                    
-                    // Execute the custom query and put the output to the output file
-                    // in the dump directory.
-                    //
-                    ExecuteCustomQuery(
-                        queryFilePath,
-                        fpath,
-                        serverInfo->m_hostname, 
-                        serverInfo->m_username,
-                        serverInfo->m_password);
+                    if (!userQueriesPath.empty())
+                    {
+                        // Construct the full path name to the query file
+                        //
+                        queryFilePath = StringFormat("%s/%s", userQueriesPath.c_str(), filename.c_str());
+
+                        // Execute the custom query and put the output to the output file
+                        // in the dump directory.
+                        //
+                        ExecuteCustomQuery(
+                            queryFilePath,
+                            fpath,
+                            serverInfo->m_hostname, 
+                            serverInfo->m_username,
+                            serverInfo->m_password);
+                    }
                 }
             }
             else

--- a/source/sqlfs.cpp
+++ b/source/sqlfs.cpp
@@ -1204,7 +1204,7 @@ InitializeSQLFs(
     for (auto&& itr : g_ServerInfoMap)
     {
         entry = itr.second;
-        CreateDMVFiles(itr.first, 
+        CreateDbfsFiles(itr.first,
             entry->m_hostname, 
             entry->m_username,
             entry->m_password, 


### PR DESCRIPTION
Make customQueriesPath config an optional config

Populate all files in customqueries dir when DBFS start up. This is so that the user can access the file directly with full path name.