### PR TITLE
rhel7 spec: syntax fix

### DIFF
--- a/rhel7/dbfs.spec.tmpl
+++ b/rhel7/dbfs.spec.tmpl
@@ -9,11 +9,11 @@ License:        MIT
 
 Requires: glibc, fuse, fuse-devel, freetds
 
-%description
-This package contains the Microsoft DBFS tool which can be used to fetch certain DMVs from SQL Servers using FUSE filesystem.
-
 %{?systemd_requires}
 BuildRequires: systemd
+
+%description
+This package contains the Microsoft DBFS tool which can be used to fetch certain DMVs from SQL Servers using FUSE filesystem.
 
 %install
 cd %{_srcdir}


### PR DESCRIPTION
Accidentally bumped into this:
```
$ rpm -qip https://packages.microsoft.com/yumrepos/microsoft-rhel7.3-prod/dbfs-0.1.5-0.x86_64.rpm
Name        : dbfs
Version     : 0.1.5
Release     : 0
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 6702811
License     : MIT
Signature   : RSA/SHA256, Mon, May  1, 2017 23:26:28, Key ID eb3e94adbe1229cf
Source RPM  : dbfs-0.1.5-0.src.rpm
Build Date  : Mon, May  1, 2017 22:55:58
Build Host  : localhost
Relocations : (not relocatable)
Summary     : Microsoft DBFS 0.1.5
Description :
This package contains the Microsoft DBFS tool which can be used to fetch certain DMVs from SQL Servers using FUSE filesystem.


Requires(post): systemd
Requires(preun): systemd
Requires(postun): systemd

BuildRequires: systemd

$ rpm -qp https://packages.microsoft.com/yumrepos/microsoft-rhel7.3-prod/dbfs-0.1.5-0.x86_64.rpm --requires
glibc
fuse
fuse-devel
freetds
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(PayloadIsXz) <= 5.2-1
```

It means `systemd` requirements are not actually applied to the package.
Instead the respective lines are appended to description.

It's just an unnoticed syntax error, this trivial PR fixes it.